### PR TITLE
fix an uncaught TypeError when trying to use json() to parse an error message

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -123,7 +123,9 @@ function WSRPC(protocol, url, defaultHeaders, disableWebsocket) {
 					res.json().then(onmessage, onmessage)
 				},
 				function (err) {
-					err.json().then(onmessage, onmessage)
+					typeof err.json === 'function'
+						? err.json().then(onmessage, onmessage)
+						: onmessage({ error: err, message: 'there was an error, but it could not be parsed as json' })
 				}
 			)
 		}


### PR DESCRIPTION
fix an uncaught TypeError when trying to use json() to parse an error message